### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,7 @@
       "source" : "git://github.com/jonathanstowe/Util-Bitfield.git"
    },
    "source-url" : "git://github.com/jonathanstowe/Util-Bitfield.git",
-   "license" : "perl",
+   "license" : "Artistic-2.0",
    "version" : "0.0.2",
    "authors" : [
       "Jonathan Stowe <jns+gh@gellyfish.co.uk>"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license